### PR TITLE
Fix JSX Spread Attributes error.

### DIFF
--- a/react-jsx.d.ts
+++ b/react-jsx.d.ts
@@ -1,5 +1,7 @@
 declare module React {
     interface TopLevelAPI {
         jsx: (jsx?: string) => React.ReactElement<any>;
+        
+        __spread: any; // for JSX Spread Attributes
     }
 }


### PR DESCRIPTION
The problem code:

```ts
///<reference path='react.d.ts' />
///<reference path='react-jsx.d.ts' />
import React = require('react/addons');

var props = { foo: 'default' };
var component = React.jsx(`<div {...props} foo={'override'} />`);
console.log(component.props.foo); // 'override'
```

When this code compiled, occurs the error shown below:

```
Property '__spread' does not exist on type 'AddonsExports'.
```

The reason why it occurred the error is that it generates the code shown below:

```ts
var props = { foo: 'default' };
var component = React.createElement("div", React.__spread({},  props, {foo: 'override'}));
console.log(component.props.foo); // 'override'
```
Therefore, I added `__spread` property to `React.TopLevelAPI` in `react-jsx.d.ts`.
