### PR TITLE
Added regex to transform JSX between /*jsx*/ comments.

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,4 +24,5 @@ module.exports = function (content) {
   return content
     .replace(/React\.jsx\(`([^`\\]*(\\.[^`\\]*)*)`\)/gm, replace) // using template strings
     .replace(/React\.jsx\(\/\*((.|[\r\n])*?)\*\/\)/gm, replace) // using multiline comments
+    .replace(/\/\*jsx\*\/((.|[\r\n])*?)\/\*jsx\*\//gm, replace); // using jsx comments
 }

--- a/test/jsx-comment.test
+++ b/test/jsx-comment.test
@@ -1,0 +1,11 @@
+class Test {
+    render() {
+        return (
+            /*jsx*/
+            <div>
+                <span>Testing</span>
+            </div>
+            /*jsx*/
+        )
+    }
+}

--- a/test/jsx-comment.test.output
+++ b/test/jsx-comment.test.output
@@ -1,0 +1,11 @@
+class Test {
+    render() {
+        return (
+            (
+            React.createElement("div", null, 
+                React.createElement("span", null, "Testing")
+            )
+            )
+        )
+    }
+}


### PR DESCRIPTION
Hi James,

Thnx for publishing this workaround! I've added the ability to transform JSX between two /*jsx*/ comment blocks. This will allow users to use the JSX syntax formatting and highlighting for .ts files. The JSX formatting is more important for me than the Typescript formatting.

Greetings,

Niek