### PR TITLE
Embedded expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,13 @@ React.render(React.jsx(/*
     </div>
 */), document.body)
 
-// or if you're using TypeScript 1.4 or above with template strings
+// or if you're using TypeScript 1.4 or above with template strings, with or without embedded expressions
+
+React.render(React.jsx(`
+    <div>
+        <span>${message}</span>
+    </div>
+`), document.body)
 
 React.render(React.jsx(`
     <div>

--- a/index.js
+++ b/index.js
@@ -29,8 +29,13 @@ module.exports = function (content) {
     return '(' + reactCode + ')'
   };
 
+  var dollarBraceReplace = function (match, jsx) {
+    jsx = jsx.replace(/\$\{(.*?)\}/gm, "{$1}");
+    return replace(match, jsx);
+  };
+
   return content
-    .replace(new RegExp(identifier + '\\(\\s*?`([^`\\\\]*(\\\\.[^`\\\\]*)*)`\\s*?\\)', 'gm'), replace) // using template strings
+    .replace(new RegExp(identifier + '\\(\\s*?`([^`\\\\]*(\\\\.[^`\\\\]*)*)`\\s*?\\)', 'gm'), dollarBraceReplace) // using template strings
     .replace(new RegExp(identifier + '\\(\\/\\*((.|[\\r\\n])*?)\\*\\/\\)', 'gm'), replace) // using multiline comments
     .replace(/\/\*jsx\*\/((.|[\r\n])*?)\/\*jsx\*\//gm, replace); // using jsx comments
 }

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = function (content) {
   };
 
   var dollarBraceReplace = function (match, jsx) {
-    jsx = jsx.replace(/\$\{(.*?)\}/gm, "{$1}");
+    jsx = jsx.replace(/\$\{([^]*?)\}/gm, "{$1}");
     return replace(match, jsx);
   };
 

--- a/test/dollar-brace.test
+++ b/test/dollar-brace.test
@@ -10,6 +10,16 @@ class Test {
 
 class Test {
     render() {
+        return React.jsx(`
+            <div dangerouslySetInnerHTML=${{
+                __html: this.static
+            }}></div>
+        `);
+    }
+}
+
+class Test {
+    render() {
         var validString = `This is a valid template string ${this.static}`;
         return React.jsx(/*
             <div>

--- a/test/dollar-brace.test
+++ b/test/dollar-brace.test
@@ -2,7 +2,7 @@ class Test {
     render() {
         return React.jsx(`
             <div>
-                <span prop=${this.static}>Testing</span>
+                <span prop=${this.static}>More $ $$ signs ${this.static}</span>
             </div>
         `);
     }

--- a/test/dollar-brace.test
+++ b/test/dollar-brace.test
@@ -1,0 +1,20 @@
+class Test {
+    render() {
+        return React.jsx(`
+            <div>
+                <span prop=${this.static}>Testing</span>
+            </div>
+        `);
+    }
+}
+
+class Test {
+    render() {
+        var validString = `This is a valid template string ${this.static}`;
+        return React.jsx(/*
+            <div>
+                <span>Cost: 5${this.static}</span>
+            </div>
+        */);
+    }
+}

--- a/test/dollar-brace.test.output
+++ b/test/dollar-brace.test.output
@@ -1,0 +1,20 @@
+class Test {
+    render() {
+        return (
+            React.createElement("div", null, 
+                React.createElement("span", {prop: this.static}, "Testing")
+            )
+        );
+    }
+}
+
+class Test {
+    render() {
+        var validString = `This is a valid template string ${this.static}`;
+        return (
+            React.createElement("div", null, 
+                React.createElement("span", null, "Cost: 5$", this.static)
+            )
+        );
+    }
+}

--- a/test/dollar-brace.test.output
+++ b/test/dollar-brace.test.output
@@ -2,7 +2,7 @@ class Test {
     render() {
         return (
             React.createElement("div", null, 
-                React.createElement("span", {prop: this.static}, "Testing")
+                React.createElement("span", {prop: this.static}, "More $ $$ signs ", this.static)
             )
         );
     }

--- a/test/dollar-brace.test.output
+++ b/test/dollar-brace.test.output
@@ -10,6 +10,16 @@ class Test {
 
 class Test {
     render() {
+        return (
+            React.createElement("div", {dangerouslySetInnerHTML: {
+                __html: this.static
+            }})
+        );
+    }
+}
+
+class Test {
+    render() {
         var validString = `This is a valid template string ${this.static}`;
         return (
             React.createElement("div", null, 

--- a/test/run.js
+++ b/test/run.js
@@ -35,7 +35,8 @@ runTests([
   'es5',
   'harmony',
   'jsx-comment',
-  'stringtemplate'
+  'stringtemplate',
+  'dollar-brace'
 ])
 
 runTests([


### PR DESCRIPTION
The great thing about using the React.jsx() syntax over a TypeScript fork such as jsx-typescript is that it doesn't break intellisense and syntax highlighting in existing TypeScript editors. The tradeoff, though, is that we get no language support within our jsx strings. However, we could leverage embedded expressions within template strings to add autocompletion for embedded javascript:

![image](https://cloud.githubusercontent.com/assets/696206/7758449/aaa9e3a0-ffbe-11e4-84c6-15a09f0bdf31.png)

This syntax is very similar to the simple brace syntax used in JSX, and can be implemented as a simple find and replace of '${}' to '{}' before hitting the jsx compiler. It also won't break any existing use cases - within ES6 template strings, '${' unambiguously refers to the beginning of an embedded expression. Because the actual value of the expression is evaluated at run-time, this currently has no meaning (and will fail) when inside a React.jsx() call, which is essentially a compile-time directive.
